### PR TITLE
feat(k3s): make cluster HA

### DIFF
--- a/data/machines.csv
+++ b/data/machines.csv
@@ -1,3 +1,4 @@
 hostname,nic_mac_address,ubuntu_distro,admin_user_name,admin_public_ssh_key,is_k3s_master
 dematu01,f4:ee:08:b9:26:c0,noble,felix-seifert,gh:felix-seifert,true
-dematu02,6c:2b:59:3a:69:b9,noble,felix-seifert,gh:felix-seifert,false
+dematu02,6c:2b:59:3a:69:b9,noble,felix-seifert,gh:felix-seifert,true
+dematu03,b4:45:06:09:55:a7,noble,felix-seifert,gh:felix-seifert,true

--- a/docs/explanations/k3s-high-availability-cluster.md
+++ b/docs/explanations/k3s-high-availability-cluster.md
@@ -1,0 +1,15 @@
+# K3s High Availability Cluster
+
+A K3s cluster consists out of several compute nodes, and these nodes can have different roles. Classically, a cluster
+has one master node and several worker nodes. And as this master node's availability is crucial for the availability of
+the whole cluster, this node is a bottleneck.
+
+To circumvent this, it is possible to create a cluster with several master nodes. Usually, this would require a shared
+database for all the master nodes. A solution with slightly less performance is having a local etcd data store for each
+master node to implement a highly available K3s cluster. Just keep in mind to have an
+[odd number of master nodes](https://docs.k3s.io/datastore/ha-embedded) because the several etcd instances must reach
+quorum.
+
+With our Ansible playbook for setting up a K3s cluster, we use the data from `data/machines.csv` to spin up the cluster.
+The role defining variable is `is_k3s_master`: when the value is `true`, the node will be a K3s master. Remember to have
+an odd number of `true` values for this variable.


### PR DESCRIPTION
Implementing HA cluster is supported by the k3s-ansible collection we use for deploying the cluster. We simply have to change the roles of the nodes which should have the `master` role.