### PR TITLE
docs: describe architecture (with diagram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,28 @@ In this repo, I codified some of the knowledge needed to set up my own bare meta
 should help future me and others being interested in this project. Furthermore, this code tries to make the taken steps
 reproducible.
 
-The overall plan is to run Kubernetes on a bare metal cluster of thin clients. The thin clients are managed
-by [Metal as a Service (MaaS)](https://maas.io/) running on a separate machine.
+The overall plan is to run Kubernetes on a bare metal cluster of thin clients. The thin clients are managed by
+[Metal as a Service (MAAS)](https://maas.io/) running on a separate machine, and the Kubernetes cluster running on top
+of the is a high availability K3s cluster.
 
-MaaS simplifies provisioning these machines with minimal physical interaction. The Ansible playbook `maas_ops.yaml` is
-for setting up the MaaS controller machine. The `Makefile` simplifies the relevant Ansible command options.
+## MAAS Setup
+
+MAAS simplifies provisioning these machines with minimal physical interaction. The Ansible playbook `maas_ops.yaml` is
+for setting up the MAAS controller machine. The `Makefile` simplifies the relevant Ansible command options.
+
+## MAAS Actions via Terraform
+
+MAAS is used to provision the thin clients in a usable state. To avoid unreproducable point-and-click configuration in
+the MAAS web UI, Terraform is used to trigger the MAAS APIs. Furthermore, it shows an understandable model of the
+infrastructure with the machine data in `data/machines.csv`.
+
+## K3s Cluster Deployment
+
+[I decided](./docs/adrs/01-deploy-k3s-through-ansible.md) to deploy the K3s Kubernetes cluster with Ansible on top of
+the machines provisioned by MAAS. The cluster is implemented as a
+[high availability](./docs/explanations/k3s-high-availability-cluster.md) cluster based on data in `data/machines.csv`.
+
+## Architecture
+
+To visualise the idea of how the different components are architected for deploying a K3s Kubernetes cluster, have a
+look at the [architecture diagram](./docs/explanations/architecture.md).

--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -1,0 +1,8 @@
+# Architecture
+
+The following architecture diagram gives an idea of how the bare metal machines form a K3s Kubernetes cluster.
+
+![Architecture Diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/felix-seifert/gohfert-cluster/refs/heads/main/docs/explanations/architecture.pumls)
+
+Even though it might look slightly confusing, we indeed have [several master nodes](./k3s-high-availability-cluster.md)
+for achieving a high availability architecture.

--- a/docs/explanations/architecture.puml
+++ b/docs/explanations/architecture.puml
@@ -1,0 +1,69 @@
+@startuml
+skin rose
+skinparam Shadowing false
+'skinparam linetype ortho
+'skinparam linetype polyline
+'skinparam nodesep 50
+skinparam ranksep 80
+
+
+rectangle "Developer VLAN" {
+    agent "Dev Machine" as dev
+}
+
+rectangle "VLAN 150" {
+    rectangle "Raspberry Pi" as pi {
+        component MAAS as maas
+        [<font:monospace> </font>] as invi
+        circle " " as jump
+    }
+
+    node "Dell Wyse 5070" as dell1 {
+        component "K3s Master" as k3s1
+    }
+
+    node "Dell Wyse 5070" as dell2 {
+        component "K3s Master" as k3s2
+    }
+
+    node "Dell Wyse 5070" as dell3 {
+        component "K3s Master" as k3s3
+    }
+
+'    node "Dell Wyse 5070" as dell4 {
+'        component "K3s Worker" as k3s4
+'    }
+
+    component "K3s Cluster" as cluster
+}
+
+dev --> pi: "1. Configure\nvia Ansible"
+dev -[#blue]-> maas: "2. Call via\nTerraform"
+
+maas -[#blue]-> dell1: Deploy\n(via Terraform)
+maas -[#blue]-> dell2: Deploy\n(via Terraform)
+maas -[#blue]-> dell3: Deploy\n(via Terraform)
+'maas -[#red]-> dell4: Deploy\n(via Terraform)
+
+dev -[#green]-> jump: "3. Jump\nwith Ansible"
+jump --[#green]--> k3s1: Deploy\n(via Ansible)
+jump --[#green]--> k3s2: Deploy\n(via Ansible)
+jump --[#green]--> k3s3: Deploy\n(via Ansible)
+'jump --[#green]--> k3s4
+
+k3s1 --> cluster
+k3s2 --> cluster
+k3s3 --> cluster
+'k3s4 --> cluster
+
+hide invi
+hide invi2
+
+<style>
+.invi {
+    BackgroundColor transparent
+    LineColor transparent
+}
+</style>
+
+@enduml


### PR DESCRIPTION
To circumvent the issue of not being able to dynamically render PUML on GitHub, we use the PUML proxy service to which we just have to hand a URL to our raw PUML file to get a rendered image back.