### PR TITLE
feat: use collection `techno_tim.k3s_ansible` to deploy K3s

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,4 +2,6 @@ skip_list:
   - var-naming[no-role-prefix]
 
 exclude_paths:
+  - .venv
   - ansible/roles/geerlingguy*
+  - ansible/ansible_collections

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ansible/roles/*
 !ansible/roles/custom_*
 
+# Purely external collections which are installed dynamically with ansible/requirements.yaml
+ansible/ansible_collections
+
 .ansible
 .idea
 .venv

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@ TAGS ?= all
 VAULT ?= --vault-password-file vault-pass.txt
 ARGS ?=
 
-DEPLOY_K3S_CLUSTER_PLAYBOOK := k3s.orchestration.site
-RESET_K3S_CLUSTER_PLAYBOOK := k3s.orchestration.reset
-REBOOT_K3S_CLUSTER_PLAYBOOK := k3s.orchestration.reboot
-UPGRADE_K3S_CLUSTER_PLAYBOOK := k3s.orchestration.upgrade
+K3S_ANSIBLE_COLLECTION := $(ANSIBLE_SUBDIR)/ansible_collections/techno_tim/k3s_ansible
+DEPLOY_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/site.yml
+RESET_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/reset.yml
+REBOOT_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/reboot.yml
 
-.PHONY: check-terraform lint run clean help deploy-k3s-cluster destroy-k3s-cluster reboot-k3s-cluster-nodes upgrade-k3s-cluster-nodes
+.PHONY: check-terraform lint run clean help deploy-k3s-cluster destroy-k3s-cluster reboot-k3s-cluster-nodes
 
 .DEFAULT_GOAL := help
 
@@ -61,17 +61,14 @@ run: venv
 	@echo "Running playbook: $(PLAYBOOK)"
 	@$(ANSIBLE_PLAYBOOK) $(PLAYBOOK) --tags $(TAGS) $(VAULT) $(ARGS)
 
-deploy-k3s-cluster:
+deploy-k3s-cluster: venv
 	$(MAKE) run PLAYBOOK=$(DEPLOY_K3S_CLUSTER_PLAYBOOK)
 
-destroy-k3s-cluster:
+destroy-k3s-cluster: venv
 	$(MAKE) run PLAYBOOK=$(RESET_K3S_CLUSTER_PLAYBOOK)
 
-reboot-k3s-cluster-nodes:
+reboot-k3s-cluster-nodes: venv
 	$(MAKE) run PLAYBOOK=$(REBOOT_K3S_CLUSTER_PLAYBOOK)
-
-upgrade-k3s-cluster-nodes:
-	$(MAKE) run PLAYBOOK=$(UPGRADE_K3S_CLUSTER_PLAYBOOK)
 
 clean:
 	@rm -rf $(VENV)
@@ -92,6 +89,4 @@ help:
 	@echo "                             in data/machines.csv"
 	@echo "  destroy-k3s-cluster        Destroy existing K3s cluster on machines in data/machines.csv"
 	@echo "  reboot-k3s-cluster-nodes   Reboot K3s nodes/machines in data/machines.csv one by one "
-	@echo "  upgrade-k3s-cluster-nodes  Upgrade K3s nodes/machines in data/machines.csv one by one to"
-	@echo "                             match K3s version in inventory"
 	@echo "  clean                      Remove virtual environment"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ANSIBLE_PLAYBOOK := $(VENV)/bin/ansible-playbook
 ANSIBLE_GALAXY := $(VENV)/bin/ansible-galaxy
 ANSIBLE_LINT := $(VENV)/bin/ansible-lint
 ANSIBLE_SUBDIR := ansible
+ANSIBLE_COLLECTIONS_SUBDIR := $(ANSIBLE_SUBDIR)/ansible_collections
 
 TF := terraform
 TF_SUBDIR := terraform
@@ -45,7 +46,7 @@ $(VENV): requirements.txt $(ANSIBLE_SUBDIR)/requirements.yaml
 	@$(PIP) install -r requirements.txt
 	@if [ -f $(ANSIBLE_SUBDIR)/requirements.yaml ]; then \
 		echo "Installing Ansible Galaxy roles/collections..."; \
-		$(ANSIBLE_GALAXY) install -r $(ANSIBLE_SUBDIR)/requirements.yaml; \
+		$(ANSIBLE_GALAXY) collection install -r $(ANSIBLE_SUBDIR)/requirements.yaml --force; \
 	fi
 	touch $(VENV)
 
@@ -73,6 +74,10 @@ reboot-k3s-cluster-nodes: venv
 clean:
 	@rm -rf $(VENV)
 	@echo "Cleaned up virtual environment."
+	@find $(ANSIBLE_SUBDIR)/roles -maxdepth 1 -mindepth 1 -type d ! -name 'custom_*' -exec rm -rf {} +
+	@echo "Cleaned up installed Ansible Galaxy roles."
+	@rm -rf $(ANSIBLE_COLLECTIONS_SUBDIR)
+	@echo "Cleaned up installed Ansible Galaxy collections."
 
 help:
 	@echo "Usage: make [target]"
@@ -89,4 +94,4 @@ help:
 	@echo "                             in data/machines.csv"
 	@echo "  destroy-k3s-cluster        Destroy existing K3s cluster on machines in data/machines.csv"
 	@echo "  reboot-k3s-cluster-nodes   Reboot K3s nodes/machines in data/machines.csv one by one "
-	@echo "  clean                      Remove virtual environment"
+	@echo "  clean                      Remove virtual environment and installed Ansible Galaxy collections/roles"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 inventory = ./ansible/inventory/hosts, ./ansible/inventory/dynamic_k3s_cluster.py
 roles_path = ./ansible/roles
+collections_path = ./ansible
 
 retry_files_enabled = False
 host_key_checking = False

--- a/ansible/inventory/group_vars/k3s_cluster/k3s.yaml
+++ b/ansible/inventory/group_vars/k3s_cluster/k3s.yaml
@@ -1,7 +1,72 @@
 ---
-# Jinja to be resolved by Ansible
-api_endpoint: "{{ hostvars[groups['server'] | first]['ansible_host'] | default(groups['server'] | first) }}"
-
 k3s_version: "v1.33.4+k3s1"
 
-token: "{{ vault_k3s_token }}"
+k3s_token: "{{ vault_k3s_token }}"
+
+systemd_dir: /etc/systemd/system
+
+# Set your timezone
+system_timezone: "Europe/Amsterdam"
+
+# interface which will be used for flannel
+flannel_iface: "eth0"
+
+cilium_bgp: false
+
+# apiserver_endpoint is virtual ip-address which will be configured on each master
+apiserver_endpoint: "192.168.150.200"
+
+# The IP on which the node is reachable in the cluster.
+# Here, a sensible default is provided, you can still override
+# it for each of your hosts, though.
+k3s_node_ip: "{{ ansible_facts[(cilium_iface | default(calico_iface | default(flannel_iface)))]['ipv4']['address'] }}"
+
+# Disable the taint manually by setting: k3s_master_taint = false
+k3s_master_taint: "{{ true if groups['node'] | default([]) | length >= 1 else false }}"
+
+# these arguments are recommended for servers as well as agents:
+extra_args: >-
+  {{ '--flannel-iface=' + flannel_iface if calico_iface is not defined and cilium_iface is not defined else '' }}
+  --node-ip={{ k3s_node_ip }}
+
+# change these to your liking, the only required are: --disable servicelb, --tls-san {{ apiserver_endpoint }}
+# the contents of the if block is also required if using calico or cilium
+extra_server_args: >-
+  {{ extra_args }}
+  {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_master_taint else '' }}
+  {% if calico_iface is defined or cilium_iface is defined %}
+  --flannel-backend=none
+  --disable-network-policy
+  --cluster-cidr={{ cluster_cidr | default('10.52.0.0/16') }}
+  {% endif %}
+  --tls-san {{ apiserver_endpoint }}
+  --disable servicelb
+  --disable traefik
+  --write-kubeconfig-mode=644
+
+extra_agent_args: >-
+  {{ extra_args }}
+
+# image tag for kube-vip
+kube_vip_tag_version: "v1.0.0"
+
+# metallb type frr or native
+metal_lb_type: "native"
+
+# metallb mode layer2 or bgp
+metal_lb_mode: "layer2"
+
+# bgp options
+# metal_lb_bgp_my_asn: "64513"
+# metal_lb_bgp_peer_asn: "64512"
+# metal_lb_bgp_peer_address: "192.168.30.1"
+
+# image tag for metal lb
+metal_lb_speaker_tag_version: "v0.15.2"
+metal_lb_controller_tag_version: "v0.15.2"
+
+# metallb ip range for load balancer
+metal_lb_ip_range: "192.168.150.210-192.168.150.229"
+
+proxmox_lxc_configure: false
+custom_registries: false

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -4,6 +4,16 @@ roles:
     version: "4.0.1"
 
 collections:
-  - name: https://github.com/k3s-io/k3s-ansible.git
+  - name: https://github.com/timothystewart6/k3s-ansible
     type: git
-    version: 5a19438
+    version: 668d7fb896c226cde2960491a60b917db8a4bf7e # 1.30.2
+
+  # Needed for timothystewart6/k3s-ansible
+  - name: ansible.utils
+    version: 6.0.0
+  - name: community.general
+    version: 11.2.1
+  - name: ansible.posix
+    version: 2.1.0
+  - name: kubernetes.core
+    version: 6.1.0

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,14 @@
+# Requirements
+
+To deploy and operate your own Kubernetes cluster from scratch with the described methods, you require setting up the
+following specific tooling:
+
+* Python (not too old, 3.12 and newer sounds suitable)
+* Terraform
+* kubectl
+    1. For letting kubectl connect to your Kubernetes cluster from your local machine on your network, copy the
+       `$Home/.kube/config` from one of your master nodes to your local machine at the same location.
+        * The used Ansible collection `techno_tim.k3s_ansible` already copies the kubeconfig to its playbook dir and you
+          can also take it from there.
+    2. On the master nodes, kubectl already intends to connect to the virtual IP of the master nodes, i.e. any available
+       master node, and the address will not have to be adjusted anymore.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 ansible==11.8.0
 ansible-lint==25.6.1
+
+# Required by techno_tim/k3s_ansible
+netaddr==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible==11.8.0
-ansible-lint==25.6.1
+ansible-core==2.19.1
+ansible-lint==25.8.2
 
 # Required by techno_tim/k3s_ansible
 netaddr==1.3.0


### PR DESCRIPTION
This enables deploying K3s with MetalLB and Kube-VIP. Rebooting the K3s nodes is now not staggered anymore, and a specific upgrade flow for K3s is also not available.