### PR TITLE
feat: deploy self-hosted GHA runner in own network

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,5 +3,7 @@ skip_list:
 
 exclude_paths:
   - .venv
+  - "ansible/inventory/group_vars/*/vault.yaml"
   - ansible/roles/geerlingguy*
+  - ansible/roles/monolithprojects*
   - ansible/ansible_collections

--- a/ansible/inventory/group_vars/gha_runners/github.yaml
+++ b/ansible/inventory/group_vars/gha_runners/github.yaml
@@ -1,0 +1,8 @@
+---
+account: felix-seifert
+repo: gohfert-cluster
+
+github_pat: "{{ vault_github_pat }}"
+gha_runner_user: gha-runner
+
+gha_runner_version: "2.328.0"

--- a/ansible/inventory/group_vars/gha_runners/main.yaml
+++ b/ansible/inventory/group_vars/gha_runners/main.yaml
@@ -1,0 +1,6 @@
+---
+ansible_env:
+  LANG: C
+  LC_ALL: C
+
+ansible_python_interpreter: /usr/bin/python3.12

--- a/ansible/inventory/group_vars/gha_runners/vault.yaml
+++ b/ansible/inventory/group_vars/gha_runners/vault.yaml
@@ -1,0 +1,2 @@
+# Unencrypted dummy
+vault_github_pat: appropriate-github-pat

--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,2 +1,5 @@
 [maas_hosts]
 maas_host_1 ansible_host=maas.cluster.gohfert.com ansible_user=felix-seifert
+
+[gha_runners]
+gha_runner_1 ansible_host=maas.cluster.gohfert.com ansible_user=felix-seifert

--- a/ansible/playbooks/gha_runners.yaml
+++ b/ansible/playbooks/gha_runners.yaml
@@ -1,0 +1,24 @@
+---
+- name: Ensure presence of runner user
+  hosts: gha_runners
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Ensure presence of runner user
+      ansible.builtin.user:
+        name: "{{ gha_runner_user }}"
+        state: present
+        create_home: false
+        shell: /bin/bash
+
+- name: Install GitHub Actions runner
+  hosts: gha_runners
+  become: true
+  vars:
+    access_token: "{{ github_pat }}"
+    github_account: "{{ account }}"
+    github_repo: "{{ repo }}"
+    runner_user: "{{ gha_runner_user }}"
+    runner_version: "{{ gha_runner_version }}"
+  roles:
+    - role: monolithprojects.github_actions_runner

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,9 +1,16 @@
 ---
 roles:
+  # For setting up PostgreSQL database
   - name: geerlingguy.postgresql
     version: "4.0.1"
 
+  # For installing self-hosted GitHub Actions runner
+  - name: monolithprojects.github_actions_runner
+    version: ed4b47a28940824d5b25822df41c638e5eba96a5 # 1.26.0
+    src: https://github.com/MonolithProjects/ansible-github_actions_runner
+
 collections:
+  # For deploying K3s cluster
   - name: https://github.com/timothystewart6/k3s-ansible
     type: git
     version: 668d7fb896c226cde2960491a60b917db8a4bf7e # 1.30.2


### PR DESCRIPTION
Besides exposing myself to handling self-hosted GitHub Actions (GHA) runners, this provides me with the advantage that I can run GHA workflows within my own network without the nasty move of exposing parts of the network.