### PR TITLE
feat: allow staggered reboot of K3s cluster nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TF := terraform
 TF_SUBDIR := terraform
 TF_PLAN := tfplan
 
-PLAYBOOK ?= ansible/playbooks/maas_ops.yaml
+PLAYBOOK ?= $(ANSIBLE_SUBDIR)/playbooks/maas_ops.yaml
 TAGS ?= all
 VAULT ?= --vault-password-file vault-pass.txt
 ARGS ?=
@@ -19,7 +19,7 @@ ARGS ?=
 K3S_ANSIBLE_COLLECTION := $(ANSIBLE_SUBDIR)/ansible_collections/techno_tim/k3s_ansible
 DEPLOY_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/site.yml
 RESET_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/reset.yml
-REBOOT_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/reboot.yml
+REBOOT_K3S_CLUSTER_PLAYBOOK := $(ANSIBLE_SUBDIR)/playbooks/k3s_node_reboot.yaml
 
 .PHONY: check-terraform lint run clean help deploy-k3s-cluster destroy-k3s-cluster reboot-k3s-cluster-nodes
 
@@ -72,7 +72,7 @@ destroy-k3s-cluster: venv
 	$(MAKE) run PLAYBOOK=$(RESET_K3S_CLUSTER_PLAYBOOK)
 
 reboot-k3s-cluster-nodes: venv
-	$(MAKE) run PLAYBOOK=$(REBOOT_K3S_CLUSTER_PLAYBOOK)
+	$(MAKE) run PLAYBOOK=$(REBOOT_K3S_CLUSTER_PLAYBOOK) ARGS="--extra-vars 'concurrent_reboots=1 wait_seconds_after_reboot=30'"
 
 plan: init
 	$(TF) -chdir=$(TF_SUBDIR) plan -out=$(TF_PLAN)

--- a/ansible/playbooks/k3s_node_reboot.yaml
+++ b/ansible/playbooks/k3s_node_reboot.yaml
@@ -1,0 +1,29 @@
+---
+- name: Reboot masters and nodes with optional concurrency
+  hosts: k3s_cluster
+  gather_facts: false
+  become: true
+
+  # concurrent_reboots defines how many hosts to reboot concurrently, if not defined, all hosts rebooted at once
+  serial: "{{ concurrent_reboots | default('100%') }}"
+
+  tasks:
+    - name: >-
+        {{
+          'Reboot all nodes at once'
+          if (concurrent_reboots is not defined)
+          else 'Reboot nodes with concurrency of ' ~ concurrent_reboots
+        }}
+      ansible.builtin.reboot:
+        reboot_command: "{{ custom_reboot_command | default(omit) }}"
+        reboot_timeout: 300
+        test_command: >-
+          {{ 'kubectl get nodes' if 'master' in group_names else 'whoami' }}
+
+    - name: Optional wait after reboot before next rebooting next node
+      ansible.builtin.pause:
+        seconds: "{{ wait_seconds_after_reboot | default(0) }}"
+      when: >-
+        concurrent_reboots is defined and
+        wait_seconds_after_reboot is defined and
+        wait_seconds_after_reboot | int > 0


### PR DESCRIPTION
Rebooting the K3s cluster nodes will now not bring the whole cluster down anymore. A PR for the optional staggered reboot process got [also created upstream](https://github.com/timothystewart6/k3s-ansible/pull/661). Once this upstream PR is merged, the staggered reboot could be used from there.