### PR TITLE
fix: assign static IP to MAAS server

### DIFF
--- a/ansible/inventory/group_vars/maas_hosts/main.yaml
+++ b/ansible/inventory/group_vars/maas_hosts/main.yaml
@@ -4,3 +4,10 @@ ansible_env:
   LC_ALL: C
 
 ansible_python_interpreter: /usr/bin/python3.12
+
+networking:
+  nic: eth0
+  ip_address: 192.168.150.2/24
+  gateway: 192.168.150.1
+  dns_servers:
+    - 192.168.150.1

--- a/ansible/playbooks/maas_ops.yaml
+++ b/ansible/playbooks/maas_ops.yaml
@@ -19,6 +19,26 @@
             name: custom_apt_upgrade
 
 
+- name: Ensure static IP address
+  hosts: maas_hosts
+  tags: [install, upgrade]
+  become: true
+  vars:
+    run: "{{ ('install' in ansible_run_tags) or ('upgrade' in ansible_run_tags) }}"
+  tasks:
+    - name: Ensure static IP address only if `install` or `upgrade` tag is passed
+      when: run
+      block:
+        - name: Call role `custom_netplan_ip_setter` with {{ networking.ip_address }}
+          ansible.builtin.include_role:
+            name: custom_netplan_ip_setter
+          vars:
+            netplan_interface: "{{ networking.nic }}"
+            netplan_address: "{{ networking.ip_address }}"
+            netplan_gateway: "{{ networking.gateway }}"
+            netplan_nameservers: "{{ networking.dns_servers }}"
+
+
 - name: Set up DB
   hosts: maas_hosts
   tags: install

--- a/ansible/roles/custom_netplan_ip_setter/defaults/main.yaml
+++ b/ansible/roles/custom_netplan_ip_setter/defaults/main.yaml
@@ -1,0 +1,6 @@
+netplan_interface: eth0
+netplan_address: "192.168.172.11/24"
+netplan_gateway: "192.168.172.1"
+netplan_nameservers:
+  - "192.168.172.1"
+  - "8.8.8.8"

--- a/ansible/roles/custom_netplan_ip_setter/tasks/main.yaml
+++ b/ansible/roles/custom_netplan_ip_setter/tasks/main.yaml
@@ -1,0 +1,26 @@
+---
+- name: Disable cloud-init network configuration
+  ansible.builtin.copy:
+    dest: /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+    content: |
+      network: {config: disabled}
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Remove default cloud-init netplan file if it exists
+  ansible.builtin.file:
+    path: /etc/netplan/50-cloud-init.yaml
+    state: absent
+
+- name: Deploy netplan configuration
+  ansible.builtin.template:
+    src: 01-netcfg.yaml.j2
+    dest: /etc/netplan/01-netcfg.yaml
+    owner: root
+    group: root
+    mode: '0600'
+
+- name: Apply netplan configuration
+  ansible.builtin.command: netplan apply
+  changed_when: false

--- a/ansible/roles/custom_netplan_ip_setter/templates/01-netcfg.yaml.j2
+++ b/ansible/roles/custom_netplan_ip_setter/templates/01-netcfg.yaml.j2
@@ -1,0 +1,10 @@
+network:
+  version: 2
+  ethernets:
+    {{ netplan_interface }}:
+      dhcp4: no
+      addresses:
+        - {{ netplan_address }}
+      gateway4: {{ netplan_gateway }}
+      nameservers:
+        addresses: [{{ netplan_nameservers | join(', ') }}]

--- a/docs/references/router-settings-for-maas.md
+++ b/docs/references/router-settings-for-maas.md
@@ -1,9 +1,17 @@
 # Required Router Settings to Enable MAAS to Discover and Manage Servers
 
-Several network settings have to be adjusted that MAAS works. In my case, these settings have to be applied to the
-central UniFi Ubiquiti Cloud Gateway:
+A few network settings have to be adjusted so that MAAS works:
 
-* Enable DHCP while MAAS is initially setup. Somehow the fixed IP address is not reliable if no DHCP server is active.
-    * If not already done, assign a fixed IP address to the MAAS server.
-    * After the initial MAAS setup, relay the DHCP functionality of the router to the MAAS server, so that MAAS is the
-      only DHCP server of the network.
+* On its VLAN, the MAAS server should be the only DHCP server. The router DHCP server functionality would therefore have
+  to switched off.
+* So that the MAAS server is still available without an overarching DHCP server, it needs to have a static IP address.
+  As the router does not provide the DHCP server function anymore, locking the IP address on the router's side does not
+  help; the IP address will have to be set on the server itself. This ios achieved with the Ansible role
+  [custom_netplan_ip_setter](../../ansible/roles/custom_netplan_ip_setter).
+
+For setting the IP address on the server, you first have to be able to connect to the server, i.e. it needs an IP
+address. The following workflow might therefore be a good idea:
+
+1. While the router's DHCP is still enabled, assign a DNS name to the MAAS server to make it easy to address it.
+2. Set the static IP address on the MAAS server (e.g. via the `maas_ops.yaml` playbook).
+3. Disable the DHCP server functionality of the router.


### PR DESCRIPTION
Embarrassing fix :see_no_evil: 

I fixed the IP address of the MAAS server on the router. This means that the router fixed the binding `NIC's MAC address <--> IP address`. This still required some form of DHCP functionality on the router to be active, because only the router knew about this binding.

As the router's DHCP functionality was switched off, rebooting MAAS did not make the MAAS server available again. Even though the MAAS server was somewhere on the network, it did not get its usual address assigned; I simply forgot that I have to persist the IP address statically on the MAAS server itself, so that it can appear with this address again without having a DHCP server assigning this address to it.

The IP address of the MAAS server is now persisted on the server. Whenever the server reboots or becomes unavailable, it can appear again with its known IP address. And when the server has its usual IP address, the DNS resolution also works as expected and the MAAS server is available under its usual DNS domain.