### PR TITLE
fix: let MAAS server resolve DNS names as before to search `maas` doamin

### DIFF
--- a/ansible/inventory/group_vars/maas_hosts/main.yaml
+++ b/ansible/inventory/group_vars/maas_hosts/main.yaml
@@ -9,5 +9,8 @@ networking:
   nic: eth0
   ip_address: 192.168.150.2/24
   gateway: 192.168.150.1
+  search_domains:
+    - maas
   dns_servers:
+    - 127.0.0.1
     - 192.168.150.1

--- a/ansible/playbooks/maas_ops.yaml
+++ b/ansible/playbooks/maas_ops.yaml
@@ -36,6 +36,7 @@
             netplan_interface: "{{ networking.nic }}"
             netplan_address: "{{ networking.ip_address }}"
             netplan_gateway: "{{ networking.gateway }}"
+            netplan_search_domains: "{{ networking.search_domains }}"
             netplan_nameservers: "{{ networking.dns_servers }}"
 
 

--- a/ansible/roles/custom_netplan_ip_setter/templates/01-netcfg.yaml.j2
+++ b/ansible/roles/custom_netplan_ip_setter/templates/01-netcfg.yaml.j2
@@ -7,4 +7,5 @@ network:
         - {{ netplan_address }}
       gateway4: {{ netplan_gateway }}
       nameservers:
+        search: [{{ netplan_search_domains | join(', ') }}]
         addresses: [{{ netplan_nameservers | join(', ') }}]


### PR DESCRIPTION
Noteworthy changes are:
* The MAAS server has the DNS records for the machines it provisioned. It therefore has to query itself again to resolve the DNS names.
* For locally managing to resolve hostnames without adding the domain to its name, MAAS is told again to search in the `maas` domain. Now, we can again use `ping <hostname>` and do not have to type `ping <hostname>.maas`.