### PR TITLE
feat: create restricted svc for reboot on Kubernetes nodes

### DIFF
--- a/ansible/inventory/group_vars/k3s_cluster/k3s.yaml
+++ b/ansible/inventory/group_vars/k3s_cluster/k3s.yaml
@@ -68,5 +68,7 @@ metal_lb_controller_tag_version: "v0.15.2"
 # metallb ip range for load balancer
 metal_lb_ip_range: "192.168.150.210-192.168.150.229"
 
+custom_reboot_command: "sudo /sbin/reboot"
+
 proxmox_lxc_configure: false
 custom_registries: false

--- a/ansible/playbooks/k3s_node_reboot.yaml
+++ b/ansible/playbooks/k3s_node_reboot.yaml
@@ -2,7 +2,6 @@
 - name: Reboot masters and nodes with optional concurrency
   hosts: k3s_cluster
   gather_facts: false
-  become: true
 
   # concurrent_reboots defines how many hosts to reboot concurrently, if not defined, all hosts rebooted at once
   serial: "{{ concurrent_reboots | default('100%') }}"

--- a/data/service_accounts.yaml
+++ b/data/service_accounts.yaml
@@ -1,0 +1,8 @@
+---
+# These service accounts are provisioned by MAAS through its one-time cloud-init process.
+- account_name: svc-gha-ansible-reboot
+  description: GitHub Actions Ansible CI User
+  public_ssh_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaLPRZrnK/HEwLX56SbzIJlUJCkXiFLMbDCMpwg1YoR svc-gha-ansible-reboot CI key
+  allow_connections_from: "192.168.150.0/24"
+  sudo_permissions:
+    - "/sbin/reboot"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,14 @@
 locals {
-  data_dir     = "${path.root}/../data"
-  machine_data = csvdecode(file("${local.data_dir}/machines.csv"))
+  data_dir         = "${path.root}/../data"
+  machine_data     = csvdecode(file("${local.data_dir}/machines.csv"))
+  service_accounts = yamldecode(file("${local.data_dir}/service_accounts.yaml"))
+  service_accounts_normalised = [
+    for acct in local.service_accounts : merge(acct, {
+      allow_connections_from = acct.allow_connections_from == null ? [] : (
+        can(tolist(acct.allow_connections_from)) ? tolist(acct.allow_connections_from) : [acct.allow_connections_from]
+      )
+    })
+  ]
 }
 
 module "servers" {
@@ -12,4 +20,5 @@ module "servers" {
   distro_series        = each.value["ubuntu_distro"]
   admin_user_name      = each.value["admin_user_name"]
   admin_public_ssh_key = each.value["admin_public_ssh_key"]
+  service_accounts     = local.service_accounts_normalised
 }

--- a/terraform/modules/server/main.tf
+++ b/terraform/modules/server/main.tf
@@ -34,6 +34,7 @@ resource "maas_instance" "this" {
     user_data = templatefile("${path.module}/cloud-init.tpl", {
       admin_user_name      = var.admin_user_name
       admin_public_ssh_key = var.admin_public_ssh_key
+      service_accounts     = var.service_accounts
     })
   }
 

--- a/terraform/modules/server/variables.tf
+++ b/terraform/modules/server/variables.tf
@@ -3,6 +3,13 @@ variable "pxe_mac" { type = string }
 variable "distro_series" { type = string }
 variable "admin_user_name" { type = string }
 variable "admin_public_ssh_key" { type = string }
+variable "service_accounts" { type = list(object({
+  account_name           = string
+  description            = optional(string)
+  public_ssh_key         = string
+  sudo_permissions       = optional(list(string), [])
+  allow_connections_from = optional(list(string), [])
+})) }
 variable "architecture" {
   type    = string
   default = "amd64/generic"


### PR DESCRIPTION
With this PR, the machines provisioned by MAAS, the eventual Kubernetes nodes, receive a restricted service account for usage in CI. It has limited root permissions to only use sudo for rebooting the machine.

For the future, such service accounts which should be present on all Kubernetes nodes could be added to `data/service_accounts.yaml`.