### PR TITLE
ci: enable nightly reboot of K3s nodes with svc via Ansible playbook

### DIFF
--- a/.github/workflows/cron_reboot.yaml
+++ b/.github/workflows/cron_reboot.yaml
@@ -11,14 +11,23 @@ jobs:
     runs-on: maas-runner # Self-hosted runner has to be provisioned (see gha_runners.yaml Ansible playbook)
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # SHA for version 5.6.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
       - name: Set up SSH key for svc-gha-ansible-reboot
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SVC_GHA_ANSIBLE_REBOOT_SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-      - name: Test SSH connection to one node
-        run: |
-          ssh -o StrictHostKeyChecking=no \
-              -i ~/.ssh/id_ed25519 \
-              svc-gha-ansible-reboot@dematu01.maas "echo OK"
+      - name: Set up venv with dependencies
+        run: make venv
+
+      - name: Run staggered reboot
+        run: make reboot-k3s-cluster-nodes USER="svc-gha-ansible-reboot"

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,13 @@ destroy-k3s-cluster: venv
 	$(MAKE) run PLAYBOOK=$(RESET_K3S_CLUSTER_PLAYBOOK)
 
 reboot-k3s-cluster-nodes: venv
-	$(MAKE) run PLAYBOOK=$(REBOOT_K3S_CLUSTER_PLAYBOOK) ARGS="--extra-vars 'concurrent_reboots=1 wait_seconds_after_reboot=30'"
+ifeq ($(strip $(USER)),)
+	$(MAKE) run PLAYBOOK=$(REBOOT_K3S_CLUSTER_PLAYBOOK) \
+		ARGS="--extra-vars 'concurrent_reboots=1 wait_seconds_after_reboot=30'"
+else
+	$(MAKE) run PLAYBOOK=$(REBOOT_K3S_CLUSTER_PLAYBOOK) \
+		ARGS="--extra-vars 'concurrent_reboots=1 wait_seconds_after_reboot=30 ansible_user=$(USER)'"
+endif
 
 plan: init
 	$(TF) -chdir=$(TF_SUBDIR) plan -out=$(TF_PLAN)
@@ -121,7 +127,8 @@ help:
 	@echo "  deploy-k3s-cluster         Deploy fresh K3s cluster on provisioned machines based on data"
 	@echo "                             in data/machines.csv"
 	@echo "  destroy-k3s-cluster        Destroy existing K3s cluster on machines in data/machines.csv"
-	@echo "  reboot-k3s-cluster-nodes   Reboot K3s nodes/machines in data/machines.csv one by one "
+	@echo "  reboot-k3s-cluster-nodes   Reboot K3s nodes/machines in data/machines.csv one by one with waits"
+	@echo "                             Optionally pass a USER arg to execute as a different user"
 	@echo "  plan                       Check Terraform state objects' intention and store necessary changes"
 	@echo "                             in a plan file"
 	@echo "  apply                      Perform Terraform changes previously stored in a plan file"

--- a/ansible/inventory/group_vars/gha_runners/github.yaml
+++ b/ansible/inventory/group_vars/gha_runners/github.yaml
@@ -4,5 +4,6 @@ repo: gohfert-cluster
 
 github_pat: "{{ vault_github_pat }}"
 gha_runner_user: gha-runner
+gha_runner_name: maas-runner
 
 gha_runner_version: "2.328.0"

--- a/ansible/playbooks/gha_runners.yaml
+++ b/ansible/playbooks/gha_runners.yaml
@@ -1,24 +1,41 @@
 ---
-- name: Ensure presence of runner user
+- name: Manage GitHub Actions runner
   hosts: gha_runners
-  gather_facts: false
   become: true
-  tasks:
-    - name: Ensure presence of runner user
+
+  pre_tasks:
+    - name: Fail if both deploy and remove are tagged
+      ansible.builtin.fail:
+        msg: "You cannot use both 'deploy' and 'remove' tags at the same time."
+      when: "'deploy' in ansible_run_tags and 'remove' in ansible_run_tags"
+
+    - name: Set default runner_state (deploy mode)
+      ansible.builtin.set_fact:
+        gha_runner_state: started
+      when: "'remove' not in ansible_run_tags"
+
+    - name: Set runner_state to absent if remove is tagged
+      ansible.builtin.set_fact:
+        gha_runner_state: absent
+      when: "'remove' in ansible_run_tags"
+
+    - name: Ensure runner user state
       ansible.builtin.user:
         name: "{{ gha_runner_user }}"
-        state: present
-        create_home: false
+        state: "{{ 'present' if runner_state == 'started' else 'absent' }}"
+        create_home: true
         shell: /bin/bash
+      tags: always
 
-- name: Install GitHub Actions runner
-  hosts: gha_runners
-  become: true
-  vars:
-    access_token: "{{ github_pat }}"
-    github_account: "{{ account }}"
-    github_repo: "{{ repo }}"
-    runner_user: "{{ gha_runner_user }}"
-    runner_version: "{{ gha_runner_version }}"
   roles:
     - role: monolithprojects.github_actions_runner
+      vars:
+        access_token: "{{ github_pat }}"
+        github_account: "{{ account }}"
+        github_repo: "{{ repo }}"
+        runner_user: "{{ gha_runner_user }}"
+        runner_name: "{{ gha_runner_name }}"
+        runner_version: "{{ gha_runner_version }}"
+        runner_state: "{{ gha_runner_state }}"
+        runner_labels:
+          - "{{ gha_runner_name }}"


### PR DESCRIPTION
Building on top of the testing of PR #16, the GitHub Actions CRON workflow triggers a staggered reboot of all K3s nodes. This staggered reboot was implemented in PR #11 and is executed as the SVC account created in PR #15.

This PR of a recurring reboot of the K3s nodes forms a first step towards a recurring testing of the live system.