### PR TITLE
ci: improve Python caching by persisting whole venv

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,10 +15,30 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
 
       - name: Set up Python
+        id: set_up_python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # SHA for version 5.6.0
         with:
           python-version: "3.12"
-          cache: pip
+
+      - name: Get environment info
+        id: env_info
+        run: |
+          dir=$(make print-venv-dir)
+          python_reqs_file=$(make print-python-requirements-file)
+          ansible_reqs_file=$(make print-ansible-requirements-file)
+
+          echo "dir=$dir" >> $GITHUB_OUTPUT
+          echo "python_reqs_file=$python_reqs_file" >> $GITHUB_OUTPUT
+          echo "ansible_reqs_file=$ansible_reqs_file" >> $GITHUB_OUTPUT
+
+          # GitHub’s hashFiles isn’t available here, so use sha256sum
+          echo "hash=$(sha256sum $python_reqs_file | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Restore cached venv
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.hash }}
+          path: ${{ steps.env_info.outputs.dir }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # SHA for version 3.1.2
@@ -30,7 +50,15 @@ jobs:
         run: make init
 
       - name: Set up venv with dependencies
-        run: make venv
+        run: |
+          touch ${{ steps.env_info.outputs.ansible_reqs_file }}
+          make venv
+
+      - name: Cache venv
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.hash }}
+          path: ${{ steps.env_info.outputs.dir }}
 
       - name: Run linting
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ ANSIBLE_LINT := $(VENV)/bin/ansible-lint
 ANSIBLE_SUBDIR := ansible
 ANSIBLE_COLLECTIONS_SUBDIR := $(ANSIBLE_SUBDIR)/ansible_collections
 
+PYTHON_REQS_FILE := requirements.txt
+ANSIBLE_REQS_FILE := $(ANSIBLE_SUBDIR)/requirements.yaml
+
 TF := terraform
 TF_SUBDIR := terraform
 TF_PLAN := tfplan
@@ -41,15 +44,15 @@ $(TF_SUBDIR)/.terraform: $(TF_SUBDIR)/provider.tf
 
 venv: $(VENV)
 
-$(VENV): requirements.txt $(ANSIBLE_SUBDIR)/requirements.yaml
+$(VENV): $(PYTHON_REQS_FILE) $(ANSIBLE_REQS_FILE)
 	@python3 -m venv $(VENV)
 	@$(PIP) install --upgrade pip
-	@$(PIP) install -r requirements.txt
-	@if [ -f $(ANSIBLE_SUBDIR)/requirements.yaml ]; then \
+	@$(PIP) install -r $(PYTHON_REQS_FILE)
+	@if [ -f $(ANSIBLE_REQS_FILE) ]; then \
 		echo "Installing Ansible Galaxy roles..."; \
-		$(ANSIBLE_GALAXY) role install -r $(ANSIBLE_SUBDIR)/requirements.yaml --force; \
+		$(ANSIBLE_GALAXY) role install -r $(ANSIBLE_REQS_FILE) --force; \
 		echo "Installing Ansible Galaxy collections..."; \
-		$(ANSIBLE_GALAXY) collection install -r $(ANSIBLE_SUBDIR)/requirements.yaml --force; \
+		$(ANSIBLE_GALAXY) collection install -r $(ANSIBLE_REQS_FILE) --force; \
 	fi
 	touch $(VENV)
 
@@ -135,3 +138,14 @@ help:
 	@echo "  mark-for-redeployment      Mark host in var HOSTNAME for redeployment through Terraform"
 	@echo "  mark-for-recommissioning"  "Mark host in var HOSTNAME for recommissioning through Terraform"
 	@echo "  clean                      Remove virtual environment and installed Ansible Galaxy collections/roles"
+
+.PHONY: print-venv-dir print-python-requirements-file print-ansible-requirements-file
+
+print-venv-dir:
+	@echo $(VENV)
+
+print-python-requirements-file:
+	@echo $(PYTHON_REQS_FILE)
+
+print-ansible-requirements-file:
+	@echo $(ANSIBLE_REQS_FILE)


### PR DESCRIPTION
The standard pip caching only prevents the package downloads and still requires the package installation. The changes follow the approach to cache the whole venv dir instead, in which the packagees are already installed.