### PR TITLE
ci: cache Ansible collections

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,22 +23,31 @@ jobs:
       - name: Get environment info
         id: env_info
         run: |
-          dir=$(make print-venv-dir)
+          venv_dir=$(make print-venv-dir)
+          collections_dir=$(make print-ansible-collections-dir)
           python_reqs_file=$(make print-python-requirements-file)
           ansible_reqs_file=$(make print-ansible-requirements-file)
 
-          echo "dir=$dir" >> $GITHUB_OUTPUT
+          echo "venv_dir=$venv_dir" >> $GITHUB_OUTPUT
+          echo "collections_dir=$collections_dir" >> $GITHUB_OUTPUT
           echo "python_reqs_file=$python_reqs_file" >> $GITHUB_OUTPUT
           echo "ansible_reqs_file=$ansible_reqs_file" >> $GITHUB_OUTPUT
 
           # GitHub’s hashFiles isn’t available here, so use sha256sum
-          echo "hash=$(sha256sum $python_reqs_file | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+          echo "python_hash=$(sha256sum $python_reqs_file | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+          echo "ansible_hash=$(sha256sum $ansible_reqs_file | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
 
       - name: Restore cached venv
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
         with:
-          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.hash }}
-          path: ${{ steps.env_info.outputs.dir }}
+          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.python_hash }}
+          path: ${{ steps.env_info.outputs.venv_dir }}
+
+      - name: Restore cached Ansible collections
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+        with:
+          key: collections-${{ runner.os }}-${{ steps.env_info.outputs.ansible_hash }}
+          path: ${{ steps.env_info.outputs.collections_dir }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # SHA for version 3.1.2
@@ -57,8 +66,14 @@ jobs:
       - name: Cache venv
         uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
         with:
-          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.hash }}
-          path: ${{ steps.env_info.outputs.dir }}
+          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.python_hash }}
+          path: ${{ steps.env_info.outputs.venv_dir }}
+
+      - name: Cache Ansible collections
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+        with:
+          key: collections-${{ runner.os }}-${{ steps.env_info.outputs.ansible_hash }}
+          path: ${{ steps.env_info.outputs.collections_dir }}
 
       - name: Run linting
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ ANSIBLE_COLLECTIONS_SUBDIR := $(ANSIBLE_SUBDIR)/ansible_collections
 PYTHON_REQS_FILE := requirements.txt
 ANSIBLE_REQS_FILE := $(ANSIBLE_SUBDIR)/requirements.yaml
 
+# Inline Git config to silence "detached HEAD" advice
+GIT_SILENCE_DETACHED = GIT_CONFIG_COUNT=1 \
+                       GIT_CONFIG_KEY_0=advice.detachedHead \
+                       GIT_CONFIG_VALUE_0=false
+
 TF := terraform
 TF_SUBDIR := terraform
 TF_PLAN := tfplan
@@ -50,9 +55,9 @@ $(VENV): $(PYTHON_REQS_FILE) $(ANSIBLE_REQS_FILE)
 	@$(PIP) install -r $(PYTHON_REQS_FILE)
 	@if [ -f $(ANSIBLE_REQS_FILE) ]; then \
 		echo "Installing Ansible Galaxy roles..."; \
-		$(ANSIBLE_GALAXY) role install -r $(ANSIBLE_REQS_FILE) --force; \
+		$(GIT_SILENCE_DETACHED) $(ANSIBLE_GALAXY) role install -r $(ANSIBLE_REQS_FILE); \
 		echo "Installing Ansible Galaxy collections..."; \
-		$(ANSIBLE_GALAXY) collection install -r $(ANSIBLE_REQS_FILE) --force; \
+		$(GIT_SILENCE_DETACHED) $(ANSIBLE_GALAXY) collection install -r $(ANSIBLE_REQS_FILE); \
 	fi
 	touch $(VENV)
 
@@ -143,6 +148,9 @@ help:
 
 print-venv-dir:
 	@echo $(VENV)
+
+print-ansible-collections-dir:
+	@echo $(ANSIBLE_COLLECTIONS_SUBDIR)
 
 print-python-requirements-file:
 	@echo $(PYTHON_REQS_FILE)

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 inventory = ./ansible/inventory/hosts, ./ansible/inventory/dynamic_k3s_cluster.py
 roles_path = ./ansible/roles
-collections_path = ./ansible
+collections_path = ./ansible/ansible_collections
 
 retry_files_enabled = False
 host_key_checking = False


### PR DESCRIPTION
Similar to PR #20, this PR introduces caching for the used Ansible Galaxy collections declared in `ansible/requirements.yaml`. This caching does not only avoid redundant downloads but also installing the collections by putting them into the appropriate space.

Roles installed via Ansible Galaxy are NOT cached yet.