### PR TITLE
ci: update cache on pushes to main to allow reusing cache on other branches

### DIFF
--- a/.github/workflows/update_cache.yaml
+++ b/.github/workflows/update_cache.yaml
@@ -1,0 +1,55 @@
+name: update-cache
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  cache-update:
+    name: Install requirements and cache them
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+
+      - name: Set up Python
+        id: set_up_python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # SHA for version 5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Get environment info
+        id: env_info
+        run: |
+          venv_dir=$(make print-venv-dir)
+          collections_dir=$(make print-ansible-collections-dir)
+          python_reqs_file=$(make print-python-requirements-file)
+          ansible_reqs_file=$(make print-ansible-requirements-file)
+
+          echo "venv_dir=$venv_dir" >> $GITHUB_OUTPUT
+          echo "collections_dir=$collections_dir" >> $GITHUB_OUTPUT
+          echo "python_reqs_file=$python_reqs_file" >> $GITHUB_OUTPUT
+          echo "ansible_reqs_file=$ansible_reqs_file" >> $GITHUB_OUTPUT
+
+          # GitHub’s hashFiles isn’t available here, so use sha256sum
+          echo "python_hash=$(sha256sum $python_reqs_file | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+          echo "ansible_hash=$(sha256sum $ansible_reqs_file | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache venv
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.python_hash }}
+          path: ${{ steps.env_info.outputs.venv_dir }}
+
+      - name: Cache Ansible collections
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+        with:
+          key: collections-${{ runner.os }}-${{ steps.env_info.outputs.ansible_hash }}
+          path: ${{ steps.env_info.outputs.collections_dir }}
+
+      - name: Install dependencies according to requirements files
+        run: |
+          touch ${{ steps.env_info.outputs.ansible_reqs_file }}
+          make venv


### PR DESCRIPTION
Caches created on branches different from the default branch (`main`) are not available on other non-default branches. The idea is therefore to update the cache on every push to the `main` branch so that other branches can then reuse it.