### PR TITLE
feat: Kubernetes manifests for deploying `docs` internally

### DIFF
--- a/kubernetes/docs/deployment.yaml
+++ b/kubernetes/docs/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docs-deployment
+  namespace: docs-ns
+  labels:
+    app: docs
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: docs
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: docs
+    spec:
+      containers:
+        - name: docs
+          image: ghcr.io/felix-seifert/gohfert-cluster-docs:20251001-035512
+          ports:
+            - containerPort: 80

--- a/kubernetes/docs/namespace.yaml
+++ b/kubernetes/docs/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: docs-ns

--- a/kubernetes/docs/service.yaml
+++ b/kubernetes/docs/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: docs-service
+  namespace: docs-ns
+spec:
+  selector:
+    app: docs
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
These manifests are for deploying the documentation with mkdocs. The `Deployment` uses the Docker image generated by PR #31.  For security and debugging reasons, I decided to go with specific Docker image tags and not the just `latest` tag.

Using the `latest` tag, I could have simply forced the deployment to always reload the latest image. Killing the pods one by one would then have worked for updating the image. As I decided to set specific tags, I will have to update the tag when I want to use a new Docker image. This will be automated with a GHA workflow in a future PR.