### PR TITLE
ci: change Docker image tags automatically on `workflow_call`

### DIFF
--- a/.github/workflows/update_docker_image_tag.yml
+++ b/.github/workflows/update_docker_image_tag.yml
@@ -1,0 +1,70 @@
+name: update-docker-image-tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Docker image name to update'
+        required: true
+        type: string
+      tag:
+        description: 'New tag for the Docker image'
+        required: true
+        type: string
+      app:
+        description: 'Specific app/subdirectory to update (optional)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      image:
+        description: 'Docker image name to update'
+        required: true
+        type: string
+      tag:
+        description: 'New tag for the Docker image'
+        required: true
+        type: string
+      app:
+        description: 'Specific app/subdirectory to update (optional)'
+        required: false
+        type: string
+
+jobs:
+  update-image-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+
+      - name: Update Docker image tag
+        working-directory: ./kubernetes
+        run: |
+          if [ -n "${{ inputs.app }}" ]; then
+            make update-image IMAGE="${{ inputs.image }}" TAG="${{ inputs.tag }}" APP="${{ inputs.app }}"
+          else
+            make update-image IMAGE="${{ inputs.image }}" TAG="${{ inputs.tag }}"
+          fi
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config --local user.email "action@noreply.github.com"
+          git config --local user.name "Image Tag Updater"
+          git add .
+          git commit -m "chore: update ${{ inputs.image }} to tag ${{ inputs.tag }}"
+          git push
+
+      - name: No changes detected
+        if: steps.changes.outputs.has_changes == 'false'
+        run: echo "No changes detected for image ${{ inputs.image }} and new tag ${{ inputs.tag }}"


### PR DESCRIPTION
CI workflow to use some of the Makefile functionality implemented in PR #35.