### PR TITLE
ci: sign automatic Docker tag update commits as `Gohfert Tagger`

### DIFF
--- a/.github/workflows/update_docker_image_tag.yaml
+++ b/.github/workflows/update_docker_image_tag.yaml
@@ -60,14 +60,23 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Create GitHub App token for "Gohfert Tagger"
+        id: token-generator
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # SHA for version 2.1.4
+        with:
+          app-id: ${{ secrets.GOHFERT_TAGGER_APP_ID }}
+          private-key: ${{ secrets.GOHFERT_TAGGER_APP_PRIVATE_KEY }}
+
       - name: Create branch and PR with Kubernetes manifest changes
         id: pr
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # SHA for version 7.0.8
         with:
+          token: ${{ steps.token-generator.outputs.token }}
+          sign-commits: true
           commit-message: "chore: update ${{ inputs.image }} to tag ${{ inputs.tag }}"
           title: "chore: update ${{ inputs.image }}"
-          author: Image Tag Updater <image-tag-updater@users.noreply.github.com>
           add-paths: |
             ./kubernetes/
           branch: "update-to-${{ inputs.image }}-${{ inputs.tag }}"


### PR DESCRIPTION
In this PR, I followed a very clear [description of Peter Evans's action `create-pull-request`](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens). I created the GitHub App `Gohfert Tagger` which should allow me to sign commits created by this GHA workflow.