### PR TITLE
ci: call `update-image-tag` after building and pushing docs Docker image

### DIFF
--- a/.github/workflows/build_docs_image.yaml
+++ b/.github/workflows/build_docs_image.yaml
@@ -65,3 +65,21 @@ jobs:
 
       - name: Push Docker image to ghcr.io
         run: make --directory=docs push-image
+
+      - name: Get Docker image details
+        id: image_details
+        run: |
+          image_name=$(make --directory=docs --no-print-directory print-image-name)
+          image_tag=$(make --directory=docs --no-print-directory print-image-tag)
+
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
+          echo "image_tag=$image_tag" >> $GITHUB_OUTPUT
+
+  call-update-image-tag:
+    name: Call workflow to update Docker image tag in Kubernetes manifests
+    needs: build-image
+    uses: ./.github/workflows/update_docker_image_tag.yaml
+    with:
+      image: ${{ needs.image_details.outputs.image_name }}
+      tag: ${{ needs.image_details.outputs.image_tag }}
+      app: docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -62,10 +62,16 @@ clean: ## Remove virtual environment with installed Python dependencies
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9._-]+:.*?## / {printf "\033[1m\033[36m%-24s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-.PHONY: print-venv-dir print-python-requirements-file
+.PHONY: print-venv-dir print-python-requirements-file print-image-name print-image-tag
 
 print-venv-dir:
 	@echo $(VENV)
 
 print-python-requirements-file:
 	@echo $(REQS_FILE)
+
+print-image-name:
+	@echo $(IMAGE_NAME)
+
+print-image-tag:
+	@echo $(shell cat $(TAG_FILE))


### PR DESCRIPTION
After building new Docker images for docs with #31, the action cow calls the workflow from #36.