### PR TITLE
ci: remove unneeded CI permissions for unused `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/update_docker_image_tag.yaml
+++ b/.github/workflows/update_docker_image_tag.yaml
@@ -30,10 +30,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update-image-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Revert introducing the GHA permissions introduced in PR #37. As the workflow now uses a token from a GitHub App anyway, the permissions for the `GITHUB_TOKEN` are not needed anymore anyway.