### PR TITLE
feat: update SVCs on K3s nodes via ANsible avoiding MAAS redeploy

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,5 @@
 skip_list:
+  - name[template]
   - var-naming[no-role-prefix]
 
 exclude_paths:

--- a/ansible/playbooks/service_accounts.yaml
+++ b/ansible/playbooks/service_accounts.yaml
@@ -1,0 +1,53 @@
+---
+- name: Set service accounts file
+  hosts: localhost
+  gather_facts: false
+  tags: always
+
+  vars:
+    service_accounts_file: "{{ playbook_dir }}/../../data/service_accounts.yaml"
+
+  tasks:
+    - name: Load service accounts from YAML (list)
+      ansible.builtin.set_fact:
+        service_accounts: "{{ lookup('file', service_accounts_file) | from_yaml }}"
+
+
+- name: Create service accounts from data/service_accounts.yaml
+  hosts: k3s_cluster
+  become: true
+  gather_facts: false
+  tags: [create]
+  vars:
+    is_create: "{{ 'remove' not in ansible_run_tags }}"
+
+  tasks:
+    - name: Create account if `remove` tag is not passed
+      when: is_create
+      ansible.builtin.include_role:
+        name: account_creator
+      loop: "{{ hostvars['localhost']['service_accounts'] }}"
+      loop_control:
+        loop_var: acct
+      vars:
+        account: "{{ acct }}"
+
+
+- name: Remove service accounts from data/service_accounts.yaml
+  hosts: k3s_cluster
+  become: true
+  gather_facts: false
+  tags: [remove]
+  vars:
+    is_remove: "{{ 'remove' in ansible_run_tags }}"
+
+  tasks:
+    - name: Remove service accounts if `remove` tag is passed
+      when: is_remove
+      ansible.builtin.include_role:
+        name: account_remover
+      loop: "{{ hostvars['localhost']['service_accounts'] }}"
+      loop_control:
+        loop_var: acct
+      vars:
+        account: "{{ acct }}"

--- a/ansible/roles/account_creator/defaults/main.yaml
+++ b/ansible/roles/account_creator/defaults/main.yaml
@@ -1,0 +1,21 @@
+---
+account:
+  # Required: UNIX username
+  account_name: ""
+
+  # Optional: Full name / description (GECOS)
+  description: ""
+
+  # Optional: Public SSH key to install for the account.
+  # Use either:
+  # - Literal public key string (e.g., 'ssh-ed25519 AAAA... comment')
+  # - GitHub reference in the form 'gh:<github-username>' to import all keys
+  public_ssh_key: ""
+
+  # Optional: Restrict SSH key usage to the given CIDR(s).
+  # Can be a string (single CIDR) or a list of strings.
+  allow_connections_from: []
+
+  # Optional: List of commands or aliases the user can run with NOPASSWD via sudo.
+  # When empty or undefined, no sudoers file is created for the account.
+  sudo_permissions: []

--- a/ansible/roles/account_creator/tasks/main.yaml
+++ b/ansible/roles/account_creator/tasks/main.yaml
@@ -1,0 +1,86 @@
+---
+- name: Ensure service account user {{ account.account_name }} exists
+  ansible.builtin.user:
+    name: "{{ account.account_name }}"
+    comment: "{{ account.description | default('') }}"
+    shell: "/bin/bash"
+    create_home: true
+    state: present
+
+- name: Ensure .ssh directory for {{ account.account_name }} exists with correct permissions
+  ansible.builtin.file:
+    path: "/home/{{ account.account_name }}/.ssh"
+    state: directory
+    owner: "{{ account.account_name }}"
+    group: "{{ account.account_name }}"
+    mode: "0700"
+
+- name: Build connections_from options for authorized_key for {{ account.account_name }}
+  ansible.builtin.set_fact:
+    account_connections_from_options: >-
+      {{
+        (
+          'from="' ~ (
+            account.allow_connections_from
+            if account.allow_connections_from is string
+            else (account.allow_connections_from | default([])) | join(',')
+          ) ~ '"'
+        )
+        if account.allow_connections_from is defined and (
+             (account.allow_connections_from is string and account.allow_connections_from | length > 0) or
+             (account.allow_connections_from is iterable and (account.allow_connections_from | length) > 0)
+           )
+        else omit
+      }}
+  when:
+    - account.public_ssh_key is defined
+
+- name: "Install GitHub SSH public keys when public_ssh_key starts with `gh:` for {{ account.account_name }}"
+  vars:
+    gh_user: "{{ (account.public_ssh_key | string).split(':', 1)[1] }}"
+  ansible.posix.authorized_key:
+    user: "{{ account.account_name }}"
+    key: "{{ lookup('community.general.github_keys', gh_user) }}"
+    key_options: "{{ account_connections_from_options | default(omit) }}"
+    manage_dir: false
+    path: "/home/{{ account.account_name }}/.ssh/authorized_keys"
+  when:
+    - account.public_ssh_key is defined
+    - (account.public_ssh_key | string).startswith('gh:')
+
+- name: Install provided SSH public keys for {{ account.account_name }} (non-GitHub keys)
+  ansible.posix.authorized_key:
+    user: "{{ account.account_name }}"
+    key: "{{ account.public_ssh_key }}"
+    key_options: "{{ account_connections_from_options | default(omit) }}"
+    manage_dir: false
+    path: "/home/{{ account.account_name }}/.ssh/authorized_keys"
+  when:
+    - account.public_ssh_key is defined
+    - not (account.public_ssh_key | string).startswith('gh:')
+
+- name: Check if authorized_keys exists for {{ account.account_name }}
+  ansible.builtin.stat:
+    path: "/home/{{ account.account_name }}/.ssh/authorized_keys"
+  register: account_authorized_keys_stat
+
+- name: Ensure authorized_keys for {{ account.account_name }} has correct permissions
+  ansible.builtin.file:
+    path: "/home/{{ account.account_name }}/.ssh/authorized_keys"
+    state: file
+    owner: "{{ account.account_name }}"
+    group: "{{ account.account_name }}"
+    mode: "0600"
+  when: account_authorized_keys_stat.stat.exists | default(false)
+
+- name: Configure sudoers for {{ account.account_name }} with sudo_permissions
+  ansible.builtin.copy:
+    dest: "/etc/sudoers.d/{{ account.account_name }}"
+    owner: root
+    group: root
+    mode: "0440"
+    content: "{{ account.account_name }} ALL=(ALL) NOPASSWD: {{ (account.sudo_permissions | list) | join(',') }}\n"
+    validate: "visudo -cf %s"
+  when:
+    - account.sudo_permissions is defined
+    - (account.sudo_permissions | length) > 0

--- a/ansible/roles/account_remover/defaults/main.yaml
+++ b/ansible/roles/account_remover/defaults/main.yaml
@@ -1,0 +1,10 @@
+---
+account:
+  # Required: UNIX username to remove
+  account_name: ""
+
+  # Optional: Whether to remove the user's home directory
+  remove_home: true
+
+  # Optional: Whether to force removal even if the user is logged in
+  force: false

--- a/ansible/roles/account_remover/tasks/main.yaml
+++ b/ansible/roles/account_remover/tasks/main.yaml
@@ -1,0 +1,26 @@
+---
+- name: Remove sudoers file of {{ account.account_name }} if present
+  ansible.builtin.file:
+    path: "/etc/sudoers.d/{{ account.account_name }}"
+    state: absent
+  become: true
+
+- name: Remove authorized_keys of {{ account.account_name }} if present
+  ansible.builtin.file:
+    path: "/home/{{ account.account_name }}/.ssh/authorized_keys"
+    state: absent
+  become: true
+
+- name: Remove .ssh directory of {{ account.account_name }} if present
+  ansible.builtin.file:
+    path: "/home/{{ account.account_name }}/.ssh"
+    state: absent
+  become: true
+
+- name: Remove user {{ account.account_name }}
+  ansible.builtin.user:
+    name: "{{ account.account_name }}"
+    state: absent
+    remove: "{{ account.remove_home | default(true) }}"
+    force: "{{ account.force | default(false) }}"
+  become: true

--- a/terraform/modules/server/main.tf
+++ b/terraform/modules/server/main.tf
@@ -42,4 +42,10 @@ resource "maas_instance" "this" {
     name        = maas_network_interface_physical.this.name
     subnet_cidr = "192.168.150.0/24"
   }
+
+  lifecycle {
+    ignore_changes = [
+      deploy_params[0].user_data
+    ]
+  }
 }


### PR DESCRIPTION
When redeploying an instance through MAAS, the cloud-init process still creates all SVCs listed in `data/service_accounts.yaml`. After the initial deployment, Terraform ignores how the initial cloud-init config might have to look like, preventing attempts to redeploy instances. Editing the SVCs on K3s cluster nodes is now possible through `ansible/playbooks/service_accounts.yaml` with the tags `create` and `remove`.