### PR TITLE
fix(ci): Allow CI SA to create and modify `Ingress` resources

### DIFF
--- a/kubernetes/service_accounts/svc-gha-kubectl-apply.yaml
+++ b/kubernetes/service_accounts/svc-gha-kubectl-apply.yaml
@@ -51,3 +51,14 @@ rules:
       - create
       - update
       - patch
+
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch


### PR DESCRIPTION
The service account `svc-gha-kubectl-apply` did not have the appropriate permission to handle `Ingress` resources, like the one created in the previous PR #77. The following error occurred when a CI job tried to apply the K8s resources.

```
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "networking.k8s.io/v1, Resource=ingresses", GroupVersionKind: "networking.k8s.io/v1, Kind=Ingress"
Name: "docs-ingress", Namespace: "docs-ns"
from server for: "./docs/ingress.yaml": ingresses.networking.k8s.io "docs-ingress" is forbidden: User "system:serviceaccount:service-account-ns:svc-gha-kubectl-apply" cannot get resource "ingresses" in API group "networking.k8s.io" in the namespace "docs-ns"
```