### PR TITLE
fix(ci): Skip applying dir `kubernetes/service_accounts`

### DIFF
--- a/.github/workflows/kubernetes_apply_dispatch.yaml
+++ b/.github/workflows/kubernetes_apply_dispatch.yaml
@@ -26,9 +26,11 @@ jobs:
 
       - name: Extract changed subdirs from changed files
         run: |
+          # Exclude service_accounts - CI service account cannot modify its own RBAC permissions
           changed_subdirs=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" \
             | grep '^kubernetes/' \
             | cut --delimiter '/' -f2 \
+            | grep -v '^service_accounts$' \
             | sort --unique \
             | paste --serial --delimiter "," -)
 


### PR DESCRIPTION
This is a chicken-and-egg problem: the service account can't modify its own permissions (serviceaccounts, secrets, clusterroles). This is also a security best practice - a service account shouldn't be able to escalate its own privileges.