### PR TITLE
chore(k8s): bind CI SA with `ClusterRoleBinding` for all NSs

### DIFF
--- a/kubernetes/docs/namespace.yaml
+++ b/kubernetes/docs/namespace.yaml
@@ -2,18 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: docs-ns
----
-# RoleBinding for CI service account
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: svc-gha-kubectl-apply-rolebinding
-  namespace: docs-ns
-subjects:
-  - kind: ServiceAccount
-    name: svc-gha-kubectl-apply
-    namespace: service-account-ns
-roleRef:
-  kind: ClusterRole
-  name: svc-gha-kubectl-apply-clusterrole
-  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/service_accounts/namespace.yaml
+++ b/kubernetes/service_accounts/namespace.yaml
@@ -2,18 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: service-account-ns
----
-# RoleBinding for CI service account
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: svc-gha-kubectl-apply-rolebinding
-  namespace: service-account-ns
-subjects:
-  - kind: ServiceAccount
-    name: svc-gha-kubectl-apply
-    namespace: service-account-ns
-roleRef:
-  kind: ClusterRole
-  name: svc-gha-kubectl-apply-clusterrole
-  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/service_accounts/svc-gha-kubectl-apply.yaml
+++ b/kubernetes/service_accounts/svc-gha-kubectl-apply.yaml
@@ -62,3 +62,16 @@ rules:
       - create
       - update
       - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: svc-gha-kubectl-apply-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: svc-gha-kubectl-apply
+    namespace: service-account-ns
+roleRef:
+  kind: ClusterRole
+  name: svc-gha-kubectl-apply-clusterrole
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The previous approach was creating a `RoleBinding` to the SA for every NS. This would require creating a new binding for every NS the SA should manage. However, as the SA is used for CI and should manage each NS anyway, we now use the wider binding for the whole cluster.