### PR TITLE
chore: implement repeatable way to generate SSH jump host config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,18 @@ TAGS ?= all
 VAULT ?= --vault-password-file vault-pass.txt
 ARGS ?=
 
+SSH_CONFIG_FILE := ssh_config
+GENERATE_SSH_CONFIG_SCRIPT := scripts/generate_ssh_config.py
+MACHINES_CSV := data/machines.csv
+SSH_USER_CONFIG := $(HOME)/.ssh/config
+SSH_INCLUDE_LINE := Include $(abspath $(SSH_CONFIG_FILE))
+
 K3S_ANSIBLE_COLLECTION := $(ANSIBLE_SUBDIR)/ansible_collections/techno_tim/k3s_ansible
 DEPLOY_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/site.yml
 RESET_K3S_CLUSTER_PLAYBOOK := $(K3S_ANSIBLE_COLLECTION)/reset.yml
 REBOOT_K3S_CLUSTER_PLAYBOOK := $(ANSIBLE_SUBDIR)/playbooks/k3s_node_reboot.yaml
 
-.PHONY: check-terraform lint run clean help deploy-k3s-cluster destroy-k3s-cluster reboot-k3s-cluster-nodes
+.PHONY: check-terraform lint run clean help deploy-k3s-cluster destroy-k3s-cluster reboot-k3s-cluster-nodes generate-ssh-config install-ssh-config
 
 .DEFAULT_GOAL := help
 
@@ -101,6 +107,25 @@ else
 		ARGS="--extra-vars 'concurrent_reboots=1 wait_seconds_after_reboot=30 ansible_user=$(USER)'"
 endif
 
+generate-ssh-config: $(SSH_CONFIG_FILE)
+
+$(SSH_CONFIG_FILE): $(GENERATE_SSH_CONFIG_SCRIPT) $(MACHINES_CSV)
+	@./$(GENERATE_SSH_CONFIG_SCRIPT) --input $(MACHINES_CSV) --output $(SSH_CONFIG_FILE)
+
+install-ssh-config: $(SSH_CONFIG_FILE)
+	@mkdir -p $(HOME)/.ssh && chmod 700 $(HOME)/.ssh
+	@touch $(SSH_USER_CONFIG) && chmod 600 $(SSH_USER_CONFIG)
+	@if grep -qxF '$(SSH_INCLUDE_LINE)' $(SSH_USER_CONFIG); then \
+		echo "Already present in $(SSH_USER_CONFIG): $(SSH_INCLUDE_LINE)"; \
+	else \
+		tmp=$$(mktemp) && \
+		printf '%s\n\n' '$(SSH_INCLUDE_LINE)' > $$tmp && \
+		cat $(SSH_USER_CONFIG) >> $$tmp && \
+		mv $$tmp $(SSH_USER_CONFIG) && \
+		chmod 600 $(SSH_USER_CONFIG) && \
+		echo "Prepended to $(SSH_USER_CONFIG): $(SSH_INCLUDE_LINE)"; \
+	fi
+
 plan: init
 	$(TF) -chdir=$(TF_SUBDIR) plan -out=$(TF_PLAN)
 
@@ -152,6 +177,10 @@ help:
 	@echo "                             deploying the K3s cluster"
 	@echo "  reboot-k3s-cluster-nodes   Reboot K3s nodes/machines in data/machines.csv one by one with waits"
 	@echo "                             Optionally pass a USER arg to execute as a different user"
+	@echo "  generate-ssh-config        Regenerate ssh_config from data/machines.csv. Include the file"
+	@echo "                             from your ~/.ssh/config to SSH into K3s nodes via the MAAS jump host"
+	@echo "  install-ssh-config         Idempotently prepend an Include directive for ssh_config to your"
+	@echo "                             ~/.ssh/config so the K3s host entries take effect"
 	@echo "  plan                       Check Terraform state objects' intention and store necessary changes"
 	@echo "                             in a plan file"
 	@echo "  apply                      Perform Terraform changes previously stored in a plan file"

--- a/docs/content/explanations/ssh-into-k3s-nodes.md
+++ b/docs/content/explanations/ssh-into-k3s-nodes.md
@@ -1,0 +1,7 @@
+# SSH Into K3s Nodes
+
+According to our [architecture](./architecture.md), the K3s nodes are in a different VLAN than the local developer's
+machine and only reachable via jumping through the MAAS machine. For Ansible, we already define an env var in the
+`.env` file for this. To be able to manually SSH into the nodes though, you will have to add the jump host information
+to your SSH config (usually in `~/.ssh/config`). We simplified this approach with a
+[Makefile script](../guides/ssh-via-jumphost.md).

--- a/docs/content/guides/ssh-via-jumphost.md
+++ b/docs/content/guides/ssh-via-jumphost.md
@@ -1,0 +1,11 @@
+# SSH Via Jumphost
+
+Reaching the K3s nodes is often only [possible via a jump host](../explanations/ssh-into-k3s-nodes.md). These
+information can be easily persisted in the SSH config (usually in `~/.ssh/config`). To use the correct machine data
+repeatedly, use the Makefile.
+
+1. Generate a config file from our machine data with `make generate-ssh-config`.
+2. Like the generated config file in your local SSH config with `make install-ssh-config`.
+
+You can then directly SSH to the K3s nodes via the jumphost using their hostname, e.g. `ssh dematu01`. Whenever the
+used machine data changes, you can just update your SSH config with `make generate-ssh-config`.

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -38,11 +38,13 @@ nav:
       - GitHub Actions Runners: explanations/gha-runners.md
       - K3s High Availability Cluster: explanations/k3s-high-availability-cluster.md
       - MAAS Provisioning Flow: explanations/provisioning-flow.md
+      - SSH Into K3s Nodes: explanations/ssh-into-k3s-nodes.md
   - Guides:
       - Debug Network Discovery: guides/debug-network-discovery.md
       - Deploy Private GHA Runners: guides/deploy-private-gha-runners.md
       - Provision New Machine: guides/provision-new-machine.md
       - Reprovision Existing Machine: guides/reprovision-existing-machine.md
+      - SSH Via Jumphost: guides/ssh-via-jumphost.md
   - References:
       - Certificates for TLS: references/ca-certs.md
       - Client Settings for MAAS: references/client-settings-for-maas.md

--- a/scripts/generate_ssh_config.py
+++ b/scripts/generate_ssh_config.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+from pathlib import Path
+
+JUMP_HOST_ALIAS = "gohfert-jump"
+JUMP_HOST_NAME = "maas.cluster.gohfert.com"
+JUMP_HOST_USER = "felix-seifert"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    with args.input.open(newline="") as f:
+        nodes = [
+            (row["hostname"].strip(), row["admin_user_name"].strip())
+            for row in csv.DictReader(f)
+        ]
+
+    lines = [
+        "# Generated from machine data. Do not edit by hand.",
+        "# Regenerate with: make generate-ssh-config",
+        "",
+        f"Host {JUMP_HOST_ALIAS}",
+        f"    HostName {JUMP_HOST_NAME}",
+        f"    User {JUMP_HOST_USER}",
+    ]
+
+    for hostname, user in nodes:
+        lines += [
+            "",
+            f"Host {hostname}",
+            f"    HostName {hostname}",
+            f"    User {user}",
+            f"    ProxyJump {JUMP_HOST_ALIAS}",
+        ]
+
+    args.output.write_text("\n".join(lines) + "\n")
+    print(f"Wrote {len(nodes) + 1} host entries to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ssh_config
+++ b/ssh_config
@@ -1,0 +1,21 @@
+# Generated from machine data. Do not edit by hand.
+# Regenerate with: make generate-ssh-config
+
+Host gohfert-jump
+    HostName maas.cluster.gohfert.com
+    User felix-seifert
+
+Host dematu01
+    HostName dematu01
+    User felix-seifert
+    ProxyJump gohfert-jump
+
+Host dematu02
+    HostName dematu02
+    User felix-seifert
+    ProxyJump gohfert-jump
+
+Host dematu03
+    HostName dematu03
+    User felix-seifert
+    ProxyJump gohfert-jump


### PR DESCRIPTION
As the K3s nodes can not be reached directly, a jump host is used to SSH into them. This PR implements a way to let every dev repeat the required steps on an own machine.