### PR TITLE
fix(ansible): update dependencies for installing PostgreSQL

### DIFF
--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -15,6 +15,11 @@ roles:
     version: 45473959052c83b81f2a852306407c4222e47d0d # 26.0.0+1.35.1
 
 collections:
+  # For postgresql_user and postgresql_db (called by geerlingguy.postgresql)
+  # which do not live in community.general anymore
+  - name: community.postgresql
+    version: 4.2.0
+
   # For deploying K3s cluster
   - name: https://github.com/timothystewart6/k3s-ansible
     type: git


### PR DESCRIPTION
For postgresql_user and postgresql_db (called by
geerlingguy.postgresql) is now called from the
community.postgresql collection and not anymore from the community.general collection.