### PR TITLE
fix(renovate): standardise version comments to become discoverable

### DIFF
--- a/.github/actions/prepare-docs-env-composite-action/action.yaml
+++ b/.github/actions/prepare-docs-env-composite-action/action.yaml
@@ -7,7 +7,7 @@ runs:
   steps:
     - name: Set up Python
       id: set_up_python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # SHA for version 5.6.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
       with:
         python-version: "3.12"
 
@@ -25,7 +25,7 @@ runs:
 
     - name: Cache docs venv
       id: cache-venv
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
       with:
         key: venv-docs-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.python_hash }}
         path: ${{ steps.env_info.outputs.venv_dir }}

--- a/.github/actions/prepare-env-composite-action/action.yaml
+++ b/.github/actions/prepare-env-composite-action/action.yaml
@@ -7,7 +7,7 @@ runs:
   steps:
     - name: Set up Python
       id: set_up_python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # SHA for version 5.6.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
       with:
         python-version: "3.12"
 
@@ -33,21 +33,21 @@ runs:
 
     - name: Cache venv
       id: cache-venv
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
       with:
         key: venv-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ steps.env_info.outputs.python_hash }}
         path: ${{ steps.env_info.outputs.venv_dir }}
 
     - name: Cache Ansible collections
       id: cache-collections
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
       with:
         key: collections-${{ runner.os }}-${{ steps.env_info.outputs.ansible_hash }}
         path: ${{ steps.env_info.outputs.collections_dir }}
 
     - name: Cache Ansible Galaxy roles
       id: cache-roles
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # SHA for version 4.2.4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
       with:
         key: roles-${{ runner.os }}-${{ steps.env_info.outputs.ansible_hash }}
         path: ${{ steps.env_info.outputs.galaxy_roles_dir }}

--- a/.github/workflows/build_docs_image.yaml
+++ b/.github/workflows/build_docs_image.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Set up env with Python and dependencies
         uses: ./.github/actions/prepare-docs-env-composite-action
@@ -34,7 +34,7 @@ jobs:
         run: make --directory=docs build-image
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # SHA for version 3.6.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # 3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/kubernetes_apply_dispatch.yaml
+++ b/.github/workflows/kubernetes_apply_dispatch.yaml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
         with:
           fetch-depth: 0
 
       - name: Get changed files in `kubernetes/` dir
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # SHA for version 47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # 47
         with:
           files: |
             kubernetes/**

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Setup docs env with Python and dependencies
         uses: ./.github/actions/prepare-docs-env-composite-action

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Setup env with Python and Ansible dependencies
         uses: ./.github/actions/prepare-env-composite-action
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # SHA for version 3.1.2
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # 3.1.2
         with:
           terraform_version: "1.13.1"
           terraform_wrapper: false

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Get token
         id: get_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # SHA for version 3.1.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
         with:
           private-key: ${{ secrets.GOHFERT_RENOVATOR_APP_PRIVATE_KEY }}
           app-id: ${{ secrets.GOHFERT_RENOVATOR_APP_ID }}
@@ -20,10 +20,10 @@ jobs:
           repositories: 'gohfert-cluster'
 
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@f66d8679fcfcfa051abde6e7a623007173bf5164 # SHA for version 46.1.12
+        uses: renovatebot/github-action@f66d8679fcfcfa051abde6e7a623007173bf5164 # 46.1.12
         with:
           configurationFile: renovator.json
           token: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/update_cache.yaml
+++ b/.github/workflows/update_cache.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Prepare environment to ensure cache is updated
         uses: ./.github/actions/prepare-env-composite-action

--- a/.github/workflows/update_docker_image_tag.yaml
+++ b/.github/workflows/update_docker_image_tag.yaml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # SHA for version 5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Update Docker image tag
         working-directory: ./kubernetes
@@ -59,7 +59,7 @@ jobs:
       - name: Create GitHub App token for "Gohfert Tagger"
         id: token-generator
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # SHA for version 2.1.4
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # 2.1.4
         with:
           app-id: ${{ secrets.GOHFERT_TAGGER_APP_ID }}
           private-key: ${{ secrets.GOHFERT_TAGGER_APP_PRIVATE_KEY }}
@@ -67,7 +67,7 @@ jobs:
       - name: Create branch and PR with Kubernetes manifest changes
         id: pr
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # SHA for version 7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # 7.0.8
         with:
           token: ${{ steps.token-generator.outputs.token }}
           sign-commits: true


### PR DESCRIPTION
Renovate's github-actions manager recovers a digest-pinned action's version from the trailing comment, but its pin-token regex is anchored at the start of the comment and only accepts a bare version or the keywords `v/tag=/pin/renovate:/ratchet:`. The leading free text `SHA for version` broke the match.