### PR TITLE
fix(renovate): supply token for public repos to circumvent rates

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -30,3 +30,4 @@ jobs:
         env:
           RENOVATE_PLATFORM_COMMIT: 'enabled'
           RENOVATE_REPOSITORIES: 'felix-seifert/gohfert-cluster'
+          GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}


### PR DESCRIPTION
Private app tokens have a stricted rate limit. To enable looking up the details from the public dependencies, we use a token for the public github.com repos.